### PR TITLE
Cc/fixes 2020 10 27

### DIFF
--- a/frontend/src/app/pages/precise/components/preciseFormSummary.ts
+++ b/frontend/src/app/pages/precise/components/preciseFormSummary.ts
@@ -36,10 +36,6 @@ import { IODkTableRowData } from "src/app/types/odk.types";
         <mat-icon>check_box_outline_blank</mat-icon>
         {{ form.title }}
       </button>
-      <button mat-button *ngIf="form.allowRepeats" (click)="openForm(form)">
-        <mat-icon>add</mat-icon>
-        {{ form.title }}
-      </button>
     </div>
     <button
       mat-button

--- a/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.html
+++ b/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.html
@@ -37,7 +37,7 @@
         ></precise-profile-section>
       </mat-expansion-panel>
 
-      <ng-container *ngIf="profileConfirmed" [@fadeEntryExit]>
+      <div *ngIf="profileConfirmed" [@fadeEntryExit]>
         <!-- Summary Section -->
         <mat-expansion-panel class="no-padding" expanded>
           <mat-expansion-panel-header expandedHeight="48px">
@@ -76,18 +76,6 @@
           <precise-profile-baby-section
             [section]="babySection"
           ></precise-profile-baby-section>
-          <!-- Add baby section -->
-          <div
-            class="section-tile"
-            id="addBabySection"
-            (click)="addBabySection()"
-            *ngIf="
-              babySection.forms[0].entries[0] && babySections.length - 1 == i
-            "
-          >
-            <mat-icon>add</mat-icon>
-            <span>Add Baby</span>
-          </div>
         </mat-expansion-panel>
 
         <!-- TOD - ANC section -->
@@ -118,7 +106,7 @@
             [section]="sections.labSection"
           ></precise-profile-general-section>
         </mat-expansion-panel>
-      </ng-container>
+      </div>
     </mat-accordion>
 
     <!-- profile confirmation -->

--- a/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.ts
+++ b/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.ts
@@ -84,16 +84,19 @@ export class PreciseProfileComponent implements OnDestroy, OnInit {
     this.sections = sections;
   }
   private loadParticipantBabySections() {
-    // Add sections for each recorded birth (and by default 1)
-    let babyEntries = this.store.participantFormsHash.Birthbaby.entries;
-    if (babyEntries.length === 0) {
-      // by default ensure at least one placeholder baby section
-      const f2_guid_child = this.store.addParticipantBaby(false) as string;
-      babyEntries = [{ f2_guid_child }];
-    }
+    // Add sections for each recorded birth
+    const babyEntries = this.store.participantFormsHash.Birthbaby.entries;
     babyEntries.forEach((row) => {
       this.babySections.push(this._generateBabySection(row.f2_guid_child));
     });
+    // Add placeholders for additional children recorded
+    const numberOfBabies =
+      this.store.participantFormsHash.Birthmother.entries[0]
+        ?.f7_delivery_num_of_babies || 1;
+    // add at most 1 extra section to force filling in the correct order
+    if (babyEntries.length < numberOfBabies) {
+      this.addBabySection();
+    }
   }
 
   viewRevisions() {
@@ -132,9 +135,8 @@ export class PreciseProfileComponent implements OnDestroy, OnInit {
       );
       // add label from baby_id if available
       if (f.formId === "Birthbaby") {
-        section.label = entries[0]
-          ? entries[0].f9_baby_id
-          : f2_guid_child.split("_").pop();
+        section.label =
+          entries[0]?.f9_baby_id || f2_guid_child.split("_").pop();
       }
       // include fixed value to pass as f2_guid_child when opening forms
       f.mapFields.push({


### PR DESCRIPTION
- fix baby section add: Now it will populate an extra baby section only if existing sections have entry and total number of babies specified in birthbaby form. Removes explicit 'add baby' button

- fix repeated add button appearing for lab and tod forms if entries exist
