### PR TITLE
Cc/edit form field updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --open",

--- a/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.ts
+++ b/frontend/src/app/pages/precise/pages/precise-profile/precise-profile.component.ts
@@ -88,7 +88,6 @@ export class PreciseProfileComponent implements OnDestroy, OnInit {
     const expectedEntries = new Array(numberOfBabies)
       .fill(0)
       .map((_, childIndex) => `${f2_guid}_${childIndex + 1}`);
-    console.log("expectedEntries", expectedEntries);
     expectedEntries.forEach((f2_guid_child) => {
       const section = this._generateBabySection(f2_guid_child);
       this.babySections.push(section);

--- a/frontend/src/app/services/notification/notification.service.ts
+++ b/frontend/src/app/services/notification/notification.service.ts
@@ -28,9 +28,7 @@ export class NotificationService {
     });
   }
 
-  handleError(err: Error) {
-    console.error(err);
-    console.log("store events", this.storeEvents);
+  handleError(err: Error | string, additionalText: string = "") {
     const message =
       typeof err === "string"
         ? err

--- a/frontend/src/app/services/odk/odk.service.ts
+++ b/frontend/src/app/services/odk/odk.service.ts
@@ -38,8 +38,54 @@ export class OdkService {
       window.odkTables = new OdkTablesClass(notifications, this.dialog);
     }
   }
-  handleError(err: Error) {
-    this.notifications.handleError(err);
+  /**
+   * Manually update a row in the database
+   * Performs a lookup for the rowID, and if exists first checks values, and then updates if different
+   * @param jsonMap key:value pairs to update in the row
+   */
+  async updateRow(tableId: string, rowId: string, jsonMap: any = {}) {
+    const existingData = await this.query(tableId, "_id = ?", [rowId]);
+    // There should be exactly 1 row matched by the query, However for now allow more than 1
+    // (local web sql sometimes creates temporary duplicates). Possibly should reconsider in future
+    if (existingData[0]) {
+      const row = existingData[0];
+      const updates: { key: string; newValue: string; oldValue: string }[] = [];
+      Object.entries<any>(jsonMap).forEach(async ([key, newValue]) => {
+        if (!row.hasOwnProperty(key)) {
+          return this.handleError(
+            `Cannot update [${key}] on table [${tableId}] - column does not exist`
+          );
+        } else if (row[key] !== newValue) {
+          updates.push({ key, newValue, oldValue: row[key] });
+        }
+      });
+      if (updates.length > 0) {
+        const colKeys = updates.map((u) => `${u.key} = ?`).join(" ,");
+        const colVals = updates.map((u) => u.newValue);
+        const sql = `UPDATE ${tableId} SET ${colKeys} WHERE _id = ?;`;
+        colVals.push(rowId);
+        console.log("sql", sql, colVals);
+        await this.arbitraryQuery(tableId, sql, colVals);
+      } else {
+        console.log("piped data up-to-date");
+      }
+    } else {
+      console.log("Error: expected 1 Record to update, found", existingData);
+      this.handleError(`failed to update row: ${tableId} :${rowId}`);
+    }
+  }
+
+  /**
+   * Used to pass the window object from the child iframe for use within our services
+   * TODO - merge with cc-updates-2 code
+   */
+  // setWindow(window: IODKWindow) {
+  //   this.window = window;
+  //   this.setServiceReady();
+  // }
+  handleError(err: Error | string, additionalText: string = "") {
+    console.error(err);
+    this.notifications.handleError(err, additionalText);
   }
 
   addRowWithSurvey(tableId: string, formId: string, screenPath?, jsonMap?) {
@@ -124,6 +170,41 @@ export class OdkService {
         (res: IODKQueryResult) => {
           const resultsJson = queryResultToJsonArray<T>(res);
           resolve(resultsJson);
+        },
+        (err: Error) => {
+          failureCallback(err);
+          reject(err);
+        }
+      );
+    });
+  }
+  /**
+   * Execute generic query on a table (not just to specifically retrieve rows)
+   * NOTE - to execute on a non-odk table (e.g. _table_definitions) better to use local arbitrary query
+   * @param tableId - Must be a valid odk data table as metadata for the table returned in response.
+   * If querying non-odk table pass valid table and use non-odk table in sqlCommand
+   * @param sqlCommand - Full SQL command (as can be operated on any table), e.g.
+   * ```
+   * SELECT * from _table_definitions
+   * ```
+   * @param sqlBindParams - array of values to replace '?' in sql statements
+   */
+  arbitraryQuery<T>(
+    tableId: string,
+    sqlCommand: string,
+    sqlBindParams: string[] = [],
+    failureCallback = (err) =>
+      this.handleError(err, `query tableId: ${tableId}`)
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      window.odkData.arbitraryQuery(
+        tableId,
+        sqlCommand,
+        sqlBindParams,
+        null,
+        null,
+        (res: IODKQueryResult) => {
+          resolve(res);
         },
         (err: Error) => {
           failureCallback(err);

--- a/frontend/src/app/services/odk/odkData.ts
+++ b/frontend/src/app/services/odk/odkData.ts
@@ -26,6 +26,10 @@ class OdkDataClass {
     console.error("queueRequest not implemented");
     return { _callbackId: null };
   }
+  arbitraryQuery(...args) {
+    console.error("arbitraryQuery not implemented");
+    return [];
+  }
   /**
    * For mock implementation return any data as defined in the `forms/csv`
    * folder for the corresponding table (no sort/filter logic applied)

--- a/frontend/src/app/stores/precise.store.ts
+++ b/frontend/src/app/stores/precise.store.ts
@@ -227,13 +227,20 @@ export class PreciseStore {
   }
 
   /**
-   *
+   * Launch a form in ODK survey, optionally providing an existing rowId to
+   * open an existing form (otherwise creates a new entry).
+   * Additionally pipe any key-value data pairs to the form, and automatically
+   * update piped data when re-opening in edit mode
    * @param editRowId - row to load into survey for editing
    * @param jsonMap - fields to prepopulate
    * NOTE - f2_guid automatically populated for all forms
    * NOTE - any additional fields listed in formMeta also populated
    */
-  launchForm(formMeta: IFormMeta, editRowId: string = null, jsonMap: any = {}) {
+  async launchForm(
+    formMeta: IFormMeta,
+    editRowId: string = null,
+    jsonMap: any = {}
+  ) {
     let { tableId, formId } = formMeta;
     // ensure table and form ids have been properly mapped
     // note - avoid full lookup in case modified mapped fields have been pass (e.g. baby section forms)
@@ -245,7 +252,8 @@ export class PreciseStore {
     jsonMap = { ...jsonMap, ...this._generateMappedFields(formMeta.mapFields) };
     console.log("launching form", tableId, formId, editRowId, jsonMap);
     if (editRowId) {
-      // TODO - manually update piped fields
+      // manually update piped fields in case of changes
+      await this.odk.updateRow(tableId, editRowId, jsonMap);
       return this.odk.editRowWithSurvey(tableId, editRowId, formId);
     }
     return this.odk.addRowWithSurvey(tableId, formId, editRowId, jsonMap);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwbc-odkx-app",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- add sql update methods to re-pipe data on form edit. Whenever any form is opened or re-opened to add or edit a row, the piped fields model will be evaluated and and an sql update performed if required.
